### PR TITLE
Update NewApp.Gtk.fsproj

### DIFF
--- a/templates/content/blank/NewApp.Gtk/NewApp.Gtk.fsproj
+++ b/templates/content/blank/NewApp.Gtk/NewApp.Gtk.fsproj
@@ -10,6 +10,7 @@
     <RootNamespace>NewApp.Gtk</RootNamespace>
     <AssemblyName>NewApp.Gtk</AssemblyName>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Enable NuGet package restore when running with msbuild.

Tested locally (macOS) on a clean checkout.